### PR TITLE
Suppress warnings on non-numeric data in import sheets.

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: datapackimporter
 Type: Package
 Title: Utilities for importing the ICPI Data pack into DATIM
-Version: 0.2.52
+Version: 0.2.53
 Date: 2018-03-07
 Author: Jason P. Pickering, Scott Jackson, Aaron Chafetz
 Maintainer: Jason P. Pickering <jason.p.pickering@gmail.com>

--- a/R/data-pack-importer.R
+++ b/R/data-pack-importer.R
@@ -247,7 +247,7 @@ ImportSheet <- function(wb_info, schema) {
       dplyr::mutate_all(as.character) %>%
       tidyr::gather(variable, value, -c(1:7), convert = FALSE) %>%
       dplyr::filter(., value != "0") %>%
-      dplyr::filter(!is.na(value)) %>%
+      dplyr::filter(!is.na(suppressWarnings(as.numeric(value)))) %>%
       #Special handling for dedupe which is coerced to 0 and 1
       dplyr::filter( . ,!(mechid %in% c("0","00000","1","00001"))) %>%
       dplyr::select( . , orgunit = psnuuid, mech_code=mechid, type, variable, value)
@@ -324,6 +324,7 @@ ImportSheet <- function(wb_info, schema) {
       dplyr::select(-Inactive) %>%
       tidyr::gather(variable, value, -c(1:3, convert = FALSE)) %>%
       dplyr::mutate_all(as.character) %>%
+      dplyr::filter(!is.na(as.numeric(value))) %>%
       dplyr::filter(!(value == "NA")) %>%
       #Special handling for dedupe which is coerced to 0 and 1
       #Dedupe should always be dropped. 


### PR DESCRIPTION
![selection_999 165](https://user-images.githubusercontent.com/2968061/37087403-7511d534-21fa-11e8-87cb-745b577121d6.png)

In reviewing one countries submission, I got the following. 

It looks like for some reason, these formulas are either corrupted for some reason. 

We could filter out non-numeric values with this PR, but I am not sure I am comfortable making this change, as it may be covering up something deeper in the DataPack itself. 

Thoughts @jacksonsj ?