### PR TITLE
Tweak importer to only validate values we are eventually going to import

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: datapackimporter
 Type: Package
 Title: Utilities for importing the ICPI Data pack into DATIM
-Version: 0.2.55
-Date: 2018-03-07
+Version: 0.2.56
+Date: 2018-03-08
 Author: Jason P. Pickering, Scott Jackson, Aaron Chafetz
 Maintainer: Jason P. Pickering <jason.p.pickering@gmail.com>
 Description: Utilities for importing the ICPI Data Pack into DATIM.


### PR DESCRIPTION
Currently, values which will never be imported are validated for numeric validity. There may be some corner cases where this restriction is a bit too tight. 

I think this is a bit of a speculative PR, but may lower warning levels to a level which is more acceptable. 

